### PR TITLE
Prevent multiple decimal separators in the same number

### DIFF
--- a/html-css/calculator/index.html
+++ b/html-css/calculator/index.html
@@ -35,13 +35,13 @@
                         <td><button class="btn-number" id="4">4</button></td>
                         <td><button class="btn-number" id="5">5</button></td>
                         <td><button class="btn-number" id="6">6</button></td>
-                        <td><button class="btn-operator" id="-">-</button></td>
+                        <td><button class="btn-operator" id="-" data-operator="-">-</button></td>
                     </tr>
                     <tr>
                         <td><button class="btn-number" id="1">1</button></td>
                         <td><button class="btn-number" id="2">2</button></td>
                         <td><button class="btn-number" id="3">3</button></td>
-                        <td><button class="btn-operator" id="+">+</button></td>
+                        <td><button class="btn-operator" id="+" data-operator="+">+</button></td>
                     </tr>
                     <tr>
                         <td><button class="btn-operator" data-operator="()" id="()">()</button></td>

--- a/html-css/calculator/script/script.js
+++ b/html-css/calculator/script/script.js
@@ -5,11 +5,13 @@ const calculator = document.querySelector('.calculator');
 let lastResult = '';
 let openedParentheses = 0;
 let closedParentheses = 0;
+let hasDecimal = false;
 
 buttons.forEach((item) => {
     item.addEventListener('click', () => {
         const operator = item.dataset.operator;
         if (operator) {
+            hasDecimal = false;
             if (operator === 'clear') {
                 display.textContent = '';
                 lastResult = '';
@@ -22,6 +24,11 @@ buttons.forEach((item) => {
                         result = parseFloat(result.toFixed(14)); 
                     }
                     display.textContent = result;
+
+                    if (display.textContent.includes('.')) {
+                        hasDecimal = true;
+                    }
+
                     lastResult = result;
                 } catch (error) {
                     display.textContent = 'Error';
@@ -48,6 +55,14 @@ buttons.forEach((item) => {
             }
         } else {
             if (display.textContent.length < 14) {
+
+                if (item.textContent === '.') {
+                    if (hasDecimal) {
+                        return;
+                    }
+                    hasDecimal = true;
+                }
+
                 display.textContent += item.textContent;
             }
         }


### PR DESCRIPTION
## Description

This PR prevents multiple decimal separators (`.`) from being added to the same number.

## Testing instructions

- Try adding more than one decimal separator to the same number
- Try adding more than one decimal separator when there's no number
- Try adding a decimal separator when the result of an expression has no decimal separator (e.g. `10 + 2`) - you should be able to add one
- Try adding a decimal separator when the result of an expression already has a decimal operator (e.g. `10.1 + 2`) - you should not be able to add another one